### PR TITLE
6 multiple assembly support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,12 @@ A publisher used for commands and queries based on the Mediator Design Pattern.
 ![Static Badge](https://img.shields.io/badge/NOTIFY-blue)
 
 ## Table of Contents
-1. [🎁 Packages](#🎁_Packages)
-2. [Notifications](#Notifcations)
-3. [Handlers](#Handlers)
-4. [Behaviors](#Behaviors)
-5. [Pipelines](#Pipelines)
+1. [🎁 Packages](#packages)
+2. [💪 Notifications](#notifcations)
+3. [🛒 Handlers](#handlers)
+4. [🛁 Behaviors](#behaviors)
+5. [🛁 Pipelines](#pipelines)
+5. [🎉 Hosting](#hosting)
 
 ## Example
 
@@ -37,7 +38,7 @@ builder.Services.AddScribblyBroker(options =>
 {
     options.AsScoped = true;
 
-    options.Assembly = typeof(Program).Assembly;
+    options.AddHandlersFromAssembly<Program>();
 
     options
         .AddBehavior<TracingBehavior>()

--- a/example/Scribbly.Broker.Cookbook.ApiService/Program.cs
+++ b/example/Scribbly.Broker.Cookbook.ApiService/Program.cs
@@ -9,7 +9,7 @@ builder.Services.AddScribblyBroker(options =>
 {
     options.AsScoped = true;
 
-    options.Assembly = typeof(Program).Assembly;
+    options.AddHandlersFromAssembly<Program>();
 
     options
         .AddBehavior<TracingBehavior>()

--- a/source/Scribbly.Broker.MicrosoftHosting/Registration/BrokerRegistration.cs
+++ b/source/Scribbly.Broker.MicrosoftHosting/Registration/BrokerRegistration.cs
@@ -66,13 +66,7 @@ public static class BrokerRegistration
 #endif
         }
 
-        var notificationHandlers = options.Assembly
-            .GetTypes()
-            .Where(t =>
-                t is { IsInterface: false, IsAbstract: false } &&
-                t.GetInterfaces().Any(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(INotificationHandler<>)));
-
-        foreach (var implementationType in notificationHandlers)
+        foreach (var implementationType in options.NotificationHandlers)
         {
             services.AddTransient(
                 implementationType
@@ -81,13 +75,7 @@ public static class BrokerRegistration
                 implementationType);
         }
 
-        var notificationHandlersWithResponse = options.Assembly
-            .GetTypes()
-            .Where(t =>
-                t is { IsInterface: false, IsAbstract: false } &&
-                t.GetInterfaces().Any(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(INotificationHandler<,>)));
-
-        foreach (var implementationType in notificationHandlersWithResponse)
+        foreach (var implementationType in options.QueryHandlers)
         {
             services.AddTransient(
                 implementationType

--- a/source/Scribbly.Broker/Builder/HandlerTypeBuilder.cs
+++ b/source/Scribbly.Broker/Builder/HandlerTypeBuilder.cs
@@ -1,0 +1,151 @@
+﻿using System.Reflection;
+using Scribbly.Broker.Errors;
+
+namespace Scribbly.Broker;
+
+/// <summary>
+/// An implementation of the handler builder storing the discovered types in Hashsets that is later used to created instances.
+/// </summary>
+public sealed class HandlerTypeBuilder : IHandlerTypeBuilder
+{
+    private readonly HashSet<Assembly> _assemblies = [];
+    private readonly HashSet<Type> _notification = [];
+    private readonly HashSet<Type> _queries = [];
+
+    /// <inheritdoc />
+    public IReadOnlyCollection<Type> NotificationHandlers => _notification.ToList().AsReadOnly();
+
+    /// <inheritdoc />
+    public IReadOnlyCollection<Type> QueryHandlers => _queries.ToList().AsReadOnly();
+
+    /// <inheritdoc />
+    public IHandlerTypeBuilder AddHandlersFromAssembly(Assembly assembly)
+    {
+        if (!_assemblies.Add(assembly))
+        {
+            throw new DuplicateAssemblyException(assembly);
+        }
+
+        foreach (var type in GetNotificationHandlersFromAssembly(assembly))
+        {
+            if (!_notification.Add(type))
+            {
+                throw new DuplicateHandlerException(type);
+            }
+        }
+        
+        foreach (var type in GetQueryHandlersFromAssembly(assembly))
+        {
+            if (!_queries.Add(type))
+            {
+                throw new DuplicateHandlerException(type);
+            }
+        }
+
+        return this;
+    }
+
+    /// <inheritdoc />
+    public IHandlerTypeBuilder AddHandlersFromAssembly<TAssemblyMarker>()
+    {
+        var assembly = typeof(TAssemblyMarker).Assembly;
+
+        if (!_assemblies.Add(assembly))
+        {
+            throw new DuplicateAssemblyException(assembly);
+        }
+
+        foreach (var type in GetNotificationHandlersFromAssembly(assembly))
+        {
+            if (!_notification.Add(type))
+            {
+                throw new DuplicateHandlerException(type);
+            }
+        }
+
+        foreach (var type in GetQueryHandlersFromAssembly(assembly))
+        {
+            if (!_queries.Add(type))
+            {
+                throw new DuplicateHandlerException(type);
+            }
+        }
+
+        return this;
+    }
+
+    /// <inheritdoc />
+    public IHandlerTypeBuilder AddHandlersFromAssembly(Type assemblyMarker)
+    {
+        var assembly = assemblyMarker.Assembly;
+
+        if (!_assemblies.Add(assembly))
+        {
+            throw new DuplicateAssemblyException(assembly);
+        }
+
+        foreach (var type in GetNotificationHandlersFromAssembly(assembly))
+        {
+            if (!_notification.Add(type))
+            {
+                throw new DuplicateHandlerException(type);
+            }
+        }
+
+        foreach (var type in GetQueryHandlersFromAssembly(assembly))
+        {
+            if (!_queries.Add(type))
+            {
+                throw new DuplicateHandlerException(type);
+            }
+        }
+
+        return this;
+    }
+
+    /// <inheritdoc />
+    public IHandlerTypeBuilder AddHandler<THandler, TNotification>() where THandler : INotificationHandler<TNotification> where TNotification : INotification
+    {
+        var type = typeof(THandler);
+        if (!_notification.Add(type))
+        {
+            throw new DuplicateHandlerException(type);
+        }
+
+        return this;
+    }
+
+    /// <inheritdoc />
+    public IHandlerTypeBuilder AddHandler(Type handlerType)
+    {
+        if (!handlerType.IsAssignableFrom(typeof(INotificationHandler<>)))
+        {
+            throw new InvalidHandlerException(handlerType);
+        }
+
+        if (!_notification.Add(handlerType))
+        {
+            throw new DuplicateHandlerException(handlerType);
+        }
+
+        return this;
+    }
+
+    private IEnumerable<Type> GetNotificationHandlersFromAssembly(Assembly assembly)
+    {
+        return assembly.GetTypes().Where(t =>
+            t is { IsInterface: false, IsAbstract: false } &&
+            t.GetInterfaces().Any(x => 
+                x.IsGenericType && 
+                x.GetGenericTypeDefinition() == typeof(INotificationHandler<>)));
+    }
+    
+    private IEnumerable<Type> GetQueryHandlersFromAssembly(Assembly assembly)
+    {
+        return assembly.GetTypes().Where(t =>
+            t is { IsInterface: false, IsAbstract: false } &&
+            t.GetInterfaces().Any(x => 
+                x.IsGenericType && 
+                x.GetGenericTypeDefinition() == typeof(INotificationHandler<,>)));
+    }
+}

--- a/source/Scribbly.Broker/Builder/IHandlerTypeBuilder.cs
+++ b/source/Scribbly.Broker/Builder/IHandlerTypeBuilder.cs
@@ -1,0 +1,62 @@
+﻿using System.Reflection;
+using Scribbly.Broker.Errors;
+
+namespace Scribbly.Broker;
+
+/// <summary>
+/// The type handler builder is used to located and aggregate all the handlers used by the <see cref="IBroker"/>
+/// </summary>
+public interface IHandlerTypeBuilder
+{
+    /// <summary>
+    /// Readonly collection of the handlers discovered during the build processor.
+    /// </summary>
+    IReadOnlyCollection<Type> NotificationHandlers { get; }
+
+    /// <summary>
+    /// Readonly collection of the handlers discovered during the build processor.
+    /// </summary>
+    IReadOnlyCollection<Type> QueryHandlers { get; }
+
+    /// <summary>
+    /// Discovers and adds all the handlers in the provided assembly.
+    /// </summary>
+    /// <param name="assembly">The assembly containing the handlers.</param>
+    /// <exception cref="DuplicateAssemblyException">Throws when the assembly has been added more than once.</exception>
+    /// <returns>The builder to discover more handlers.</returns>
+    IHandlerTypeBuilder AddHandlersFromAssembly(Assembly assembly);
+
+    /// <summary>
+    /// Discovers and adds all the handlers in the provided types assembly.
+    /// </summary>
+    /// <typeparam name="TAssemblyMarker">A type marking the assembly</typeparam>
+    /// <exception cref="DuplicateAssemblyException">Throws when the assembly has been added more than once.</exception>
+    /// <returns>The builder to discover more handlers.</returns>
+    IHandlerTypeBuilder AddHandlersFromAssembly<TAssemblyMarker>();
+
+    /// <summary>
+    /// Discovers and adds all the handlers in the provided types assembly.
+    /// </summary>
+    /// <param name="assemblyMarker">A type marking the assembly</param>
+    /// <exception cref="DuplicateAssemblyException">Throws when the assembly has been added more than once.</exception>
+    /// <returns>The builder to discover more handlers.</returns>
+    IHandlerTypeBuilder AddHandlersFromAssembly(Type assemblyMarker);
+
+    /// <summary>
+    /// Adds a specific handler
+    /// </summary>
+    /// <typeparam name="THandler">The concrete handler type</typeparam>
+    /// <typeparam name="TNotification">The type of notification the handler handles.</typeparam>
+    /// <exception cref="DuplicateHandlerException">Throws when the handler has been added more than once.</exception>
+    /// <returns></returns>
+    IHandlerTypeBuilder AddHandler<THandler, TNotification>() where THandler : INotificationHandler<TNotification> where TNotification : INotification;
+
+    /// <summary>
+    /// Adds a specific handler
+    /// </summary>
+    /// <param name="handlerType">The concrete handler type</param>
+    /// <exception cref="InvalidOperationException">When the handler does not implement the INotificationHandler{TNotification} interface</exception>
+    /// <exception cref="DuplicateHandlerException">Throws when the handler has been added more than once.</exception>
+    /// <returns></returns>
+    IHandlerTypeBuilder AddHandler(Type handlerType);
+}

--- a/source/Scribbly.Broker/Builder/IPipelineBuilder.cs
+++ b/source/Scribbly.Broker/Builder/IPipelineBuilder.cs
@@ -1,0 +1,42 @@
+﻿using Scribbly.Broker.Pipelines;
+
+namespace Scribbly.Broker;
+
+/// <summary>
+/// Builds up a collection of behaviors known as a pipeline
+/// </summary>
+public interface IPipelineBuilder
+{
+    /// <summary>
+    /// Adds a behavior to the collection of the behaviors.
+    /// <remarks>Behaviors will be registered in the DI container and support injection.</remarks>
+    /// </summary>
+    /// <typeparam name="TBehavior">The type of behavior to add</typeparam>
+    /// <returns>The builder to add more types.</returns>
+    IPipelineBuilder AddBehavior<TBehavior>() where TBehavior : IBrokerBehavior;
+
+    /// <summary>
+    /// Adds a behavior to the collection of the behaviors.
+    /// <remarks>Behaviors will be registered in the DI container and support injection.</remarks>
+    /// </summary>
+    /// <param name="type">The type</param>
+    /// <exception cref="InvalidOperationException">When the type is not a behavior</exception>
+    /// <returns>The builder to add more types.</returns>
+    IPipelineBuilder AddBehavior(Type type);
+
+    /// <summary>
+    /// Overrides the pipelines used internally by the <see cref="IBroker"/>
+    /// and allows the consumer to inject code into the <see cref="IBrokerBehavior"/> execution pipeline
+    /// </summary>
+    /// <typeparam name="TPipeline"></typeparam>
+    /// <returns></returns>
+    IPipelineBuilder AddNotificationPipeline<TPipeline>() where TPipeline : INotificationPipeline;
+    
+    /// <summary>
+    /// Overrides the pipelines used internally by the <see cref="IBroker"/>
+    /// and allows the consumer to inject code into the <see cref="IBrokerBehavior"/> execution pipeline
+    /// </summary>
+    /// <typeparam name="TPipeline"></typeparam>
+    /// <returns></returns>
+    IPipelineBuilder AddQueryPipeline<TPipeline>() where TPipeline : IQueryPipeline;
+}

--- a/source/Scribbly.Broker/Errors/BrokerException.cs
+++ b/source/Scribbly.Broker/Errors/BrokerException.cs
@@ -1,38 +1,26 @@
 ﻿namespace Scribbly.Broker.Errors;
 
 /// <summary>
-/// A base exception for all Broker related errors.
+/// The base of all Scribbly Broker exceptions.
 /// </summary>
-public abstract class BrokerException<TNotification> : Exception where TNotification : INotification
+public abstract class BrokerException : Exception
 {
     /// <summary>
-    /// 
+    /// Creates a new broker exception
     /// </summary>
-    public Type NotificationType { get; init; }
-
-    /// <summary>
-    /// 
-    /// </summary>
-    public TNotification? Notification { get; init; }
-
-    /// <summary>
-    /// 
-    /// </summary>
-    /// <param name="message"></param>
-    public BrokerException(string message): base(message)
+    /// <param name="message">A message to store in the exception</param>
+    protected BrokerException(string message) : base(message)
     {
-        NotificationType = typeof(TNotification);
-        Notification = default;
+        
     }
-
+    
     /// <summary>
-    /// 
+    /// Wraps an exception with the broker exception
     /// </summary>
-    /// <param name="notice"></param>
-    /// <param name="message"></param>
-    public BrokerException(TNotification notice, string message): base(message)
+    /// <param name="message">A message to store in the exception</param>
+    /// <param name="innerException">The exception wrapped by the broker exception</param>
+    protected BrokerException(string message, Exception innerException) : base(message, innerException)
     {
-        NotificationType = typeof(TNotification);
-        Notification = notice;
+        
     }
 }

--- a/source/Scribbly.Broker/Errors/BrokerHandlersNotFound.cs
+++ b/source/Scribbly.Broker/Errors/BrokerHandlersNotFound.cs
@@ -1,10 +1,10 @@
 ﻿namespace Scribbly.Broker.Errors;
 
 /// <summary>
-/// An meaningful exception used when the broker can't locate a handler for the message published.
+/// A meaningful exception used when the broker can't locate a handler for the message published.
 /// </summary>
 /// <typeparam name="TNotification"></typeparam>
-public sealed class BrokerHandlersNotFound<TNotification> : BrokerException<TNotification> where TNotification : INotification
+public sealed class BrokerHandlersNotFound<TNotification> : BrokerNotificationException<TNotification> where TNotification : INotification
 {
     /// <inheritdoc />
     public BrokerHandlersNotFound() 

--- a/source/Scribbly.Broker/Errors/BrokerNotificationException.cs
+++ b/source/Scribbly.Broker/Errors/BrokerNotificationException.cs
@@ -1,0 +1,38 @@
+﻿namespace Scribbly.Broker.Errors;
+
+/// <summary>
+/// A base exception for all Broker related errors.
+/// </summary>
+public abstract class BrokerNotificationException<TNotification> : BrokerException where TNotification : INotification
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public Type NotificationType { get; init; }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public TNotification? Notification { get; init; }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="message"></param>
+    protected BrokerNotificationException(string message): base(message)
+    {
+        NotificationType = typeof(TNotification);
+        Notification = default;
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="notice"></param>
+    /// <param name="message"></param>
+    protected BrokerNotificationException(TNotification notice, string message): base(message)
+    {
+        NotificationType = typeof(TNotification);
+        Notification = notice;
+    }
+}

--- a/source/Scribbly.Broker/Errors/DuplicateAssemblyException.cs
+++ b/source/Scribbly.Broker/Errors/DuplicateAssemblyException.cs
@@ -1,0 +1,14 @@
+﻿using System.Reflection;
+
+namespace Scribbly.Broker.Errors;
+
+/// <summary>
+/// 
+/// </summary>
+public sealed class DuplicateAssemblyException : BrokerException
+{
+    /// <inheritdoc />
+    public DuplicateAssemblyException(Assembly assembly) : base($"The {assembly.FullName} has already been added")
+    {
+    }
+}

--- a/source/Scribbly.Broker/Errors/DuplicateHandlerException.cs
+++ b/source/Scribbly.Broker/Errors/DuplicateHandlerException.cs
@@ -1,0 +1,23 @@
+﻿namespace Scribbly.Broker.Errors;
+
+/// <summary>
+/// 
+/// </summary>
+public sealed class DuplicateHandlerException : BrokerException
+{
+    /// <inheritdoc />
+    public DuplicateHandlerException(Type type) : base($"The {type.Name} has already been added")
+    {
+    }
+}
+
+/// <summary>
+/// 
+/// </summary>
+public sealed class InvalidHandlerException : BrokerException
+{
+    /// <inheritdoc />
+    public InvalidHandlerException(Type type) : base($"The {type.Name} does not implement INotificationHandler")
+    {
+    }
+}

--- a/source/Scribbly.Broker/Scribbly.Broker.csproj.DotSettings
+++ b/source/Scribbly.Broker/Scribbly.Broker.csproj.DotSettings
@@ -1,5 +1,6 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=broker/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=builder/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=delegates/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=broker/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=resolvers/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/tests/Scribbly.Broker.IntegrationTests/Broker/DefaultMediatorTestingFixture.cs
+++ b/tests/Scribbly.Broker.IntegrationTests/Broker/DefaultMediatorTestingFixture.cs
@@ -15,7 +15,8 @@ public class DefaultMediatorTestingFixture : IDisposable
         services.AddScribblyBroker(ops =>
         {
             ops.AsScoped = false;
-            ops.Assembly = Assembly.GetExecutingAssembly();
+
+            ops.AddHandlersFromAssembly<DefaultMediatorTestingFixture>();
 
             ops
                 .AddBehavior<TestPipelineBehavior1>()

--- a/tests/Scribbly.Broker.IntegrationTests/Builder/Tests/HandlerTypeBuilderTests.cs
+++ b/tests/Scribbly.Broker.IntegrationTests/Builder/Tests/HandlerTypeBuilderTests.cs
@@ -1,0 +1,168 @@
+﻿using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Scribbly.Broker.Errors;
+
+namespace Scribbly.Broker.IntegrationTests.Builder.Tests;
+
+public class HandlerTypeBuilderAssemblyTests
+{
+    [Fact]
+    public void AddHandlersFromAssembly_Generic_Should_AddAllNotificationHandlers()
+    {
+        var services = new ServiceCollection();
+
+        services.AddScribblyBroker(ops =>
+        {
+            ops.AsScoped = false;
+
+            ops.AddHandlersFromAssembly<HandlerTypeBuilderAssemblyTests>();
+        });
+
+        var sp = services.BuildServiceProvider();
+
+        sp.GetRequiredService<BrokerOptions>().NotificationHandlers.Count.Should().Be(TestingConstants.NumberOfNotificationHandlers);
+    }
+    
+    [Fact]
+    public void AddHandlersFromAssembly_Generic_Should_AddAllQueryHandlers()
+    {
+        var services = new ServiceCollection();
+
+        services.AddScribblyBroker(ops =>
+        {
+            ops.AsScoped = false;
+
+            ops.AddHandlersFromAssembly<HandlerTypeBuilderAssemblyTests>();
+        });
+
+        var sp = services.BuildServiceProvider();
+
+        sp.GetRequiredService<BrokerOptions>().QueryHandlers.Count.Should().Be(TestingConstants.NumberOfQueryHandlers);
+    }
+
+    [Fact]
+    public void AddHandlersFromAssembly_Generic_Should_Throw_DuplicateAssemblyException_WhenAddedMoreThanOnce()
+    {
+        Action action = () =>
+        {
+            var services = new ServiceCollection();
+
+            services.AddScribblyBroker(ops =>
+            {
+                ops.AsScoped = false;
+
+                ops.AddHandlersFromAssembly<HandlerTypeBuilderAssemblyTests>();
+                ops.AddHandlersFromAssembly<HandlerTypeBuilderAssemblyTests>();
+            });
+        };
+
+        action.Should().Throw<DuplicateAssemblyException>();
+    }
+
+    [Fact]
+    public void AddHandlersFromAssembly_Assembly_Should_AddAllNotificationHandlers()
+    {
+        var services = new ServiceCollection();
+
+        services.AddScribblyBroker(ops =>
+        {
+            ops.AsScoped = false;
+
+            ops.AddHandlersFromAssembly(typeof(HandlerTypeBuilderAssemblyTests).Assembly);
+        });
+
+        var sp = services.BuildServiceProvider();
+
+        sp.GetRequiredService<BrokerOptions>().NotificationHandlers.Count.Should().Be(TestingConstants.NumberOfNotificationHandlers);
+    }
+
+    [Fact]
+    public void AddHandlersFromAssembly_Assembly_Should_AddAllQueryHandlers()
+    {
+        var services = new ServiceCollection();
+
+        services.AddScribblyBroker(ops =>
+        {
+            ops.AsScoped = false;
+
+            ops.AddHandlersFromAssembly(typeof(HandlerTypeBuilderAssemblyTests).Assembly);
+        });
+
+        var sp = services.BuildServiceProvider();
+
+        sp.GetRequiredService<BrokerOptions>().QueryHandlers.Count.Should().Be(TestingConstants.NumberOfQueryHandlers);
+    }
+
+    [Fact]
+    public void AddHandlersFromAssembly_Assembly_Should_Throw_DuplicateAssemblyException_WhenAddedMoreThanOnce()
+    {
+        Action action = () =>
+        {
+            var services = new ServiceCollection();
+
+            services.AddScribblyBroker(ops =>
+            {
+                ops.AsScoped = false;
+
+                ops.AddHandlersFromAssembly(typeof(HandlerTypeBuilderAssemblyTests).Assembly);
+                ops.AddHandlersFromAssembly(typeof(HandlerTypeBuilderAssemblyTests).Assembly);
+            });
+        };
+
+        action.Should().Throw<DuplicateAssemblyException>();
+    }
+
+    [Fact]
+    public void AddHandlersFromAssembly_Type_Should_AddAllNotificationHandlers()
+    {
+        var services = new ServiceCollection();
+
+        services.AddScribblyBroker(ops =>
+        {
+            ops.AsScoped = false;
+
+            ops.AddHandlersFromAssembly(typeof(HandlerTypeBuilderAssemblyTests));
+        });
+
+        var sp = services.BuildServiceProvider();
+
+        sp.GetRequiredService<BrokerOptions>().NotificationHandlers.Count.Should().Be(TestingConstants.NumberOfNotificationHandlers);
+    }
+
+    [Fact]
+    public void AddHandlersFromAssembly_Type_Should_AddAllQueryHandlers()
+    {
+        var services = new ServiceCollection();
+
+        services.AddScribblyBroker(ops =>
+        {
+            ops.AsScoped = false;
+
+            ops.AddHandlersFromAssembly(typeof(HandlerTypeBuilderAssemblyTests));
+        });
+
+        var sp = services.BuildServiceProvider();
+
+        sp.GetRequiredService<BrokerOptions>().QueryHandlers.Count.Should().Be(TestingConstants.NumberOfQueryHandlers);
+    }
+
+    [Fact]
+    public void AddHandlersFromAssembly_Type_Should_Throw_DuplicateAssemblyException_WhenAddedMoreThanOnce()
+    {
+        Action action = () =>
+        {
+            var services = new ServiceCollection();
+
+            services.AddScribblyBroker(ops =>
+            {
+                ops.AsScoped = false;
+
+                ops.AddHandlersFromAssembly(typeof(HandlerTypeBuilderAssemblyTests));
+                ops.AddHandlersFromAssembly(typeof(HandlerTypeBuilderAssemblyTests));
+            });
+        };
+
+        action.Should().Throw<DuplicateAssemblyException>();
+    }
+    
+}

--- a/tests/Scribbly.Broker.IntegrationTests/Builder/Tests/HandlerTypeBuilderTests.cs
+++ b/tests/Scribbly.Broker.IntegrationTests/Builder/Tests/HandlerTypeBuilderTests.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Scribbly.Broker.Errors;
+using Scribbly.Broker.IntegrationTests.Broker.Handlers;
 
 namespace Scribbly.Broker.IntegrationTests.Builder.Tests;
 
@@ -144,6 +145,45 @@ public class HandlerTypeBuilderAssemblyTests
         var sp = services.BuildServiceProvider();
 
         sp.GetRequiredService<BrokerOptions>().QueryHandlers.Count.Should().Be(TestingConstants.NumberOfQueryHandlers);
+    }
+    
+    [Theory]
+    [InlineData(typeof(NoticeHandler))]
+    public void AddHandlersFromAssembly_Type_Should_IncludeSpecificNotification(Type handlerToAssert)
+    {
+        var services = new ServiceCollection();
+
+        services.AddScribblyBroker(ops =>
+        {
+            ops.AsScoped = false;
+
+            ops.AddHandlersFromAssembly(typeof(HandlerTypeBuilderAssemblyTests));
+        });
+
+        var sp = services.BuildServiceProvider();
+
+        sp.GetRequiredService<BrokerOptions>().NotificationHandlers.Should().Contain(t => t == handlerToAssert);
+    }
+    
+    [Theory]
+    [InlineData(typeof(QueryHandler))]
+    [InlineData(typeof(QueryMultipleHandler1))]
+    [InlineData(typeof(QueryMultipleHandler2))]
+    [InlineData(typeof(QueryMultipleHandler3))]
+    public void AddHandlersFromAssembly_Type_Should_IncludeSpecificQuery(Type handlerToAssert)
+    {
+        var services = new ServiceCollection();
+
+        services.AddScribblyBroker(ops =>
+        {
+            ops.AsScoped = false;
+
+            ops.AddHandlersFromAssembly(typeof(HandlerTypeBuilderAssemblyTests));
+        });
+
+        var sp = services.BuildServiceProvider();
+
+        sp.GetRequiredService<BrokerOptions>().QueryHandlers.Should().Contain(t => t == handlerToAssert);
     }
 
     [Fact]

--- a/tests/Scribbly.Broker.IntegrationTests/Builder/Tests/TestingConstants.cs
+++ b/tests/Scribbly.Broker.IntegrationTests/Builder/Tests/TestingConstants.cs
@@ -1,0 +1,7 @@
+﻿namespace Scribbly.Broker.IntegrationTests.Builder.Tests;
+
+public class TestingConstants
+{
+    public const int NumberOfNotificationHandlers = 1;
+    public const int NumberOfQueryHandlers = 4;
+}

--- a/tests/Scribbly.Broker.IntegrationTests/TestingConstants.cs
+++ b/tests/Scribbly.Broker.IntegrationTests/TestingConstants.cs
@@ -1,4 +1,4 @@
-﻿namespace Scribbly.Broker.IntegrationTests.Builder.Tests;
+﻿namespace Scribbly.Broker.IntegrationTests;
 
 public class TestingConstants
 {


### PR DESCRIPTION
# Scribbly Pull Request

## Description

Adds the ability to discover types in multiple assemblies.

Options now includes several overloads that can be chained together allowing support for a multiude of handlers being discovered accross man assemblies.

```csharp
builder.Services.AddScribblyBroker(options =>
{
    options.AsScoped = true;

    options
        .AddHandlersFromAssembly<Program>()
        .AddHandlersFromAssembly<IBroker>()
        .AddHandlersFromAssembly(typeof(INotification))
        .AddHandler<WeatherForecastHandler, WeatherForecast>();

    options
        .AddBehavior<TracingBehavior>()
        .AddBehavior<ExceptionBehavior>();
});
```
## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have executed all the unit tests
- [x] I have compiled and executed the application
- [x] I have updated the documentation to reflect my changes

## Github Issues

closes #6 